### PR TITLE
[Feat/#121] [@moeum/components] popup 컴포넌트

### DIFF
--- a/packages/moeum-components/src/components/Button/Button.scss
+++ b/packages/moeum-components/src/components/Button/Button.scss
@@ -165,6 +165,8 @@
   opacity: 1;
   transition: opacity 0.2s;
   display: flex;
+  width: 100%;
+  justify-content: center;
   align-items: center;
   flex-direction: row;
 

--- a/packages/moeum-components/src/components/Popup/Popup.scss
+++ b/packages/moeum-components/src/components/Popup/Popup.scss
@@ -1,0 +1,95 @@
+.popup {
+  background-color: var(--seed-ui-color-background-white);
+  border-radius: 16px;
+  box-shadow: 0px 4px 16px 0px rgba(109, 109, 109, 0.07);
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 100%;
+  max-width: 450px;
+  max-height: 85vh;
+  padding: 24px 16px;
+  animation: popup-content-show 150ms cubic-bezier(0.16, 1, 0.3, 1);
+  overflow-y: auto;
+
+  &:focus {
+    outline: none;
+  }
+
+  // Layout variants
+  &--layout-typeA {
+    // Default popup layout
+  }
+
+  &--layout-typeB {
+    // Add padding at the bottom for fixed buttons
+  }
+
+  // Popup body
+  &--body {
+  }
+
+  // Actions container for Type A
+  &--actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 24px;
+
+    > * {
+      flex: 1;
+    }
+
+    &-typeB {
+      display: flex;
+      justify-content: space-between;
+      gap: 8px;
+    }
+
+    &-left {
+      min-width: 76px;
+      flex: 0 0 auto;
+    }
+
+    &-right {
+      flex: 1 1 auto;
+    }
+  }
+
+  &--overlay {
+  }
+}
+
+@keyframes popup-overlay-show {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes popup-content-show {
+  from {
+    opacity: 0;
+    transform: translate(-50%, -48%) scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: translate(-50%, -50%) scale(1);
+  }
+}
+
+.visually-hidden {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+  white-space: nowrap;
+  word-wrap: normal;
+}

--- a/packages/moeum-components/src/components/Popup/Popup.stories.tsx
+++ b/packages/moeum-components/src/components/Popup/Popup.stories.tsx
@@ -3,6 +3,8 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { Popup } from ".";
 import { Button } from "../Button";
 import { OverlayProvider, useOverlay } from "@/hooks/useOverlay";
+import { Text } from "../Text";
+import { FontWeight } from "../Text/Text.type";
 
 const meta = {
   title: "Popup",
@@ -32,12 +34,12 @@ const PopupsComponent = () => {
         buttonLayoutType="typeB"
         leftButton={
           <Button onClick={exit} type="text-none" size="lg" display="full">
-            버튼
+            <Text fontWeight={FontWeight.Regular}>버튼</Text>
           </Button>
         }
         rightButton={
           <Button onClick={exit} type="solid-red" size="lg" display="full">
-            버튼
+            <Text fontWeight={FontWeight.Regular}>버튼</Text>
           </Button>
         }
       >
@@ -72,12 +74,12 @@ const PopupsComponent = () => {
         buttonLayoutType="typeB"
         leftButton={
           <Button onClick={exit} type="text-none" size="lg" display="full">
-            버튼
+            <Text fontWeight={FontWeight.Regular}>버튼</Text>
           </Button>
         }
         rightButton={
           <Button onClick={exit} type="solid-green" size="lg" display="full">
-            버튼
+            <Text fontWeight={FontWeight.Regular}>버튼</Text>
           </Button>
         }
       >
@@ -112,7 +114,7 @@ const PopupsComponent = () => {
         buttonLayoutType="typeA"
         button={
           <Button onClick={exit} type="solid-green" size="lg" display="full">
-            버튼
+            <Text fontWeight={FontWeight.Regular}>버튼</Text>
           </Button>
         }
       >

--- a/packages/moeum-components/src/components/Popup/Popup.stories.tsx
+++ b/packages/moeum-components/src/components/Popup/Popup.stories.tsx
@@ -1,0 +1,171 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Popup } from ".";
+import { Button } from "../Button";
+import { OverlayProvider, useOverlay } from "@/hooks/useOverlay";
+
+const meta = {
+  title: "Popup",
+  component: Popup,
+  parameters: {
+    layout: "centered"
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    buttonLayoutType: {
+      options: ["typeA", "typeB"],
+      control: { type: "radio" },
+      description: "Button layout type"
+    }
+  }
+} satisfies Meta<typeof Popup>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const PopupsComponent = () => {
+  const overlay = useOverlay();
+
+  const handleClickTypeBDanger = () => {
+    overlay.open(({ exit }) => (
+      <Popup
+        buttonLayoutType="typeB"
+        leftButton={
+          <Button onClick={exit} type="text-none" size="lg" display="full">
+            버튼
+          </Button>
+        }
+        rightButton={
+          <Button onClick={exit} type="solid-red" size="lg" display="full">
+            버튼
+          </Button>
+        }
+      >
+        <p
+          style={{
+            fontWeight: 700,
+            fontSize: "var(--seed-font-size-md)",
+            lineHeight: "var(--seed-font-line-height-2xl)",
+            color: "var(--seed-ui-color-text-black)"
+          }}
+        >
+          제목
+        </p>
+        <p
+          style={{
+            marginTop: 24,
+            fontWeight: 400,
+            fontSize: "var(--seed-font-size-sm)",
+            lineHeight: "var(--seed-font-line-height-2xl)",
+            color: "var(--seed-ui-color-text-dark)"
+          }}
+        >
+          내용
+        </p>
+      </Popup>
+    ));
+  };
+
+  const handleClickTypeBPrimary = () => {
+    overlay.open(({ exit }) => (
+      <Popup
+        buttonLayoutType="typeB"
+        leftButton={
+          <Button onClick={exit} type="text-none" size="lg" display="full">
+            버튼
+          </Button>
+        }
+        rightButton={
+          <Button onClick={exit} type="solid-green" size="lg" display="full">
+            버튼
+          </Button>
+        }
+      >
+        <p
+          style={{
+            fontWeight: 700,
+            fontSize: "var(--seed-font-size-md)",
+            lineHeight: "var(--seed-font-line-height-2xl)",
+            color: "var(--seed-ui-color-text-black)"
+          }}
+        >
+          제목
+        </p>
+        <p
+          style={{
+            marginTop: 24,
+            fontWeight: 400,
+            fontSize: "var(--seed-font-size-sm)",
+            lineHeight: "var(--seed-font-line-height-2xl)",
+            color: "var(--seed-ui-color-text-dark)"
+          }}
+        >
+          내용
+        </p>
+      </Popup>
+    ));
+  };
+
+  const handleClickTypeAPrimary = () => {
+    overlay.open(({ exit }) => (
+      <Popup
+        buttonLayoutType="typeA"
+        button={
+          <Button onClick={exit} type="solid-green" size="lg" display="full">
+            버튼
+          </Button>
+        }
+      >
+        <p
+          style={{
+            fontWeight: 700,
+            fontSize: "var(--seed-font-size-md)",
+            lineHeight: "var(--seed-font-line-height-2xl)",
+            color: "var(--seed-ui-color-text-black)"
+          }}
+        >
+          제목
+        </p>
+        <p
+          style={{
+            marginTop: 24,
+            fontWeight: 400,
+            fontSize: "var(--seed-font-size-sm)",
+            lineHeight: "var(--seed-font-line-height-2xl)",
+            color: "var(--seed-ui-color-text-dark)"
+          }}
+        >
+          내용
+        </p>
+      </Popup>
+    ));
+  };
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 16,
+        alignItems: "center"
+      }}
+    >
+      <Button onClick={handleClickTypeBDanger}>Type B Popup Danger</Button>
+      <Button onClick={handleClickTypeBPrimary}>Type B Popup Primary</Button>
+      <Button onClick={handleClickTypeAPrimary}>Type A Popup Danger</Button>
+    </div>
+  );
+};
+
+export const Popups: Story = {
+  args: {
+    buttonLayoutType: "typeA"
+  },
+  render: () => {
+    return (
+      <OverlayProvider>
+        <PopupsComponent />
+      </OverlayProvider>
+    );
+  }
+};

--- a/packages/moeum-components/src/components/Popup/Popup.tsx
+++ b/packages/moeum-components/src/components/Popup/Popup.tsx
@@ -1,0 +1,44 @@
+import { Dialog } from "radix-ui";
+import cx from "classnames";
+import { PopupProps } from "./Popup.type";
+import "./Popup.scss";
+
+export const Popup: React.FC<PopupProps> = props => {
+  const { className, children, buttonLayoutType, container, title, description, onClose, ...rest } =
+    props;
+
+  return (
+    <Dialog.Root {...rest} defaultOpen>
+      <Dialog.Portal container={container || document.body}>
+        <Dialog.Overlay className="popup--overlay" onClick={onClose} />
+        <Dialog.Content
+          data-moeum-component="Popup"
+          className={cx(
+            "popup",
+            {
+              [`popup--layout-${buttonLayoutType}`]: buttonLayoutType
+            },
+            className
+          )}
+        >
+          <Dialog.Title className="visually-hidden">{title || "Popup"}</Dialog.Title>
+          <Dialog.Description className="visually-hidden">
+            {description || "Popup"}
+          </Dialog.Description>
+          <div className="popup--body">{children}</div>
+          {buttonLayoutType === "typeA" && "button" in props && props.button && (
+            <div className="popup--actions">{props.button}</div>
+          )}
+          {buttonLayoutType === "typeB" && "leftButton" in props && "rightButton" in props && (
+            <div className="popup--actions popup--actions-typeB">
+              <div className="popup--actions-left">{props.leftButton}</div>
+              <div className="popup--actions-right">{props.rightButton}</div>
+            </div>
+          )}
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+};
+
+export default Popup;

--- a/packages/moeum-components/src/components/Popup/Popup.type.ts
+++ b/packages/moeum-components/src/components/Popup/Popup.type.ts
@@ -1,0 +1,24 @@
+import { Dialog } from "radix-ui";
+import { ReactNode } from "react";
+
+export interface BasePopupProps extends Dialog.DialogProps {
+  children?: ReactNode;
+  className?: string;
+  container?: Element | DocumentFragment | null;
+  title?: string;
+  description?: string;
+  onClose?: React.MouseEventHandler<HTMLDivElement>;
+}
+
+interface TypeAPopupProps extends BasePopupProps {
+  buttonLayoutType: "typeA";
+  button?: React.ReactNode;
+}
+
+interface TypeBPopupProps extends BasePopupProps {
+  buttonLayoutType: "typeB";
+  leftButton?: React.ReactNode;
+  rightButton?: React.ReactNode;
+}
+
+export type PopupProps = TypeAPopupProps | TypeBPopupProps;

--- a/packages/moeum-components/src/components/Popup/index.ts
+++ b/packages/moeum-components/src/components/Popup/index.ts
@@ -1,0 +1,2 @@
+export { Popup } from "./Popup";
+export * from "./Popup.type";

--- a/packages/moeum-components/src/index.ts
+++ b/packages/moeum-components/src/index.ts
@@ -13,6 +13,7 @@ export { RadioGroup } from "./components/RadioGroup";
 export { Checkbox } from "./components/Checkbox";
 export { Toggle } from "./components/Toggle";
 export { Select } from "./components/Select";
+export { Popup } from "./components/Popup";
 
 export { safeLocalStorage, safeSessionStorage } from "./shared/storage";
 export { RouterProvider, useRouter } from "./hooks/useRouter";

--- a/packages/moeum-components/src/style/index.scss
+++ b/packages/moeum-components/src/style/index.scss
@@ -15,3 +15,4 @@
 @use "../components/Popover/Popover.scss";
 @use "../components/Select/Select.scss";
 @use "../components/Toggle/Toggle.scss";
+@use "../components/Popup/Popup.scss";


### PR DESCRIPTION
## 📝 PR 설명
popup 컴포넌트를 추가합니다.
<!-- PR 설명 -->

## 관련된 이슈 넘버
closes #121 
<!-- close #1 -->

## ✅ 작업 목록
- popup 컴포넌트 추가
- button content align 추가
- 디자인 토큰 적용
<!-- 이슈 작업한 내용 -->

## 📚 논의사항
- 커스텀 팝업의 경우 기존 컴포넌트와 property 연결이 필요해보입니다.
<img width="319" alt="스크린샷 2025-03-15 오후 2 36 19" src="https://github.com/user-attachments/assets/b176364a-a0f0-46d8-a2c5-f9fa30036faa" />

- max-width와 max-height의 정의를 논의하고 싶습니다(현재는 width는 450px, height는 viewport기준으로 85%로 임의 지정하였습니다)

- button의 경우 TypeA는 한개, TypeB는 두 개로 임의로 정의를 하였는데요. 혹 의도하신 바가 있다면 같이 기준을 만들어봐도 좋을 것 같습니다

<!-- 이 PR에서 더 논의할 사항 혹은 리뷰어에게 확인 요청하고 싶은 부분 기재 -->

## 📚 ETC
@ChicoCrew @widse 
<!-- Screenshot, References 기재 -->
