### PR TITLE
[Feat/#112] BottomSheet 컴포넌트 추가

### DIFF
--- a/packages/moeum-components/src/components/BottomSheet/BottomSheet.scss
+++ b/packages/moeum-components/src/components/BottomSheet/BottomSheet.scss
@@ -25,14 +25,16 @@
   height: fit-content;
   background-color: #fff;
   outline: none;
-  max-height: 95vh;
+  max-height: calc(100dvh - 32px);
   border-bottom-left-radius: 0 !important;
   border-bottom-right-radius: 0 !important;
+  overflow-y: hidden;
 }
 
-.drawer-handle {
-  margin-top: 10px;
-  width: 45px;
+.drawer-content-inner {
+  max-height: calc(100dvh - 68px); /* 핸들 높이(36px)를 고려하여 조정 */
+  overflow-y: auto; /* 스크롤 추가 */
+  -webkit-overflow-scrolling: touch; /* iOS에서 부드러운 스크롤 */
 }
 
 /** Tokens Style */
@@ -45,7 +47,7 @@
 }
 
 .bottomsheet-container--radius-medium {
-  border-radius: var(--seed-spacing-600);
+  border-radius: var(--seed-spacing-700);
 }
 
 .bottomsheet-container--radius-large {
@@ -58,4 +60,9 @@
 
 .bottomsheet-container--theme-dark {
   background-color: var(--seed-palette-color-base-800);
+}
+
+.drawer-handle {
+  height: 36px;
+  width: 100%;
 }

--- a/packages/moeum-components/src/components/BottomSheet/BottomSheet.stories.tsx
+++ b/packages/moeum-components/src/components/BottomSheet/BottomSheet.stories.tsx
@@ -9,7 +9,7 @@ import { Flex } from "../layout/Flex";
  * **vaul docs**
  * https://vaul.emilkowal.ski/api
  */
-const meta = {
+const meta: Meta<typeof BottomSheet> = {
   title: "Components/BottomSheet",
   component: BottomSheet,
   parameters: {
@@ -42,15 +42,23 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-const BottomSheetContentA = () => {
+const BottomSheetNoScroll = () => {
   return (
-    <Flex height={500} p={20} align="center" justify="center">
+    <Flex height={240} py={24} px={16} align="center" justify="center">
       BottomSheet
     </Flex>
   );
 };
 
-export const Primary: Story = {
+const BottomSheetScroll = () => {
+  return (
+    <Flex height={2000} py={24} px={16} align="center" justify="center">
+      BottomSheet
+    </Flex>
+  );
+};
+
+export const BottomSheets: Story = {
   args: {
     showHandle: true,
     radius: "medium"
@@ -59,7 +67,7 @@ export const Primary: Story = {
     // eslint-disable-next-line
     const overlay = useOverlay();
 
-    const openOverlay = () => {
+    const openNoScrollBottomSheet = () => {
       overlay.open(({ isOpen, close }) => (
         <BottomSheet
           {...args}
@@ -67,11 +75,36 @@ export const Primary: Story = {
           onClose={() => {
             close();
           }}
-          children={<BottomSheetContentA />}
+          children={<BottomSheetNoScroll />}
         />
       ));
     };
 
-    return <Button onClick={openOverlay}>Open</Button>;
+    const openScrollBottomSheet = () => {
+      overlay.open(({ isOpen, close }) => (
+        <BottomSheet
+          {...args}
+          open={isOpen}
+          onClose={() => {
+            close();
+          }}
+          children={<BottomSheetScroll />}
+        />
+      ));
+    };
+
+    return (
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: 16,
+          alignItems: "center"
+        }}
+      >
+        <Button onClick={openNoScrollBottomSheet}>Open(No Scroll)</Button>
+        <Button onClick={openScrollBottomSheet}>Open(Scroll)</Button>
+      </div>
+    );
   }
 };

--- a/packages/moeum-components/src/components/BottomSheet/BottomSheet.tsx
+++ b/packages/moeum-components/src/components/BottomSheet/BottomSheet.tsx
@@ -2,6 +2,7 @@ import cx from "classnames";
 import { Drawer } from "vaul";
 import { BottomSheetProps } from "./BottomSheet.type";
 import { SwitchCase } from "../../shared/components/SwitchCase";
+import { Flex } from "../layout/Flex";
 
 export const BottomSheet = ({
   open,
@@ -32,16 +33,20 @@ export const BottomSheet = ({
             },
             className
           )}
-          data-fotcamp-component="BottomSheet"
+          data-moeum-component="BottomSheet"
           style={{ zIndex }}
         >
           <SwitchCase
             value={String(showHandle)}
             caseBy={{
-              true: <Drawer.Handle className="drawer-handle" />
+              true: (
+                <Flex className="drawer-handle" align="center" justify="center">
+                  <Drawer.Handle style={{ width: 36 }} />
+                </Flex>
+              )
             }}
           ></SwitchCase>
-          {children}
+          <div className="drawer-content-inner">{children}</div>
         </Drawer.Content>
       </Drawer.Portal>
     </Drawer.Root>

--- a/packages/moeum-components/src/components/BottomSheet/BottomSheet.type.ts
+++ b/packages/moeum-components/src/components/BottomSheet/BottomSheet.type.ts
@@ -1,5 +1,3 @@
-import { CSSProperties } from "react";
-
 export const BottomSheetRadius = {
   NONE: "none",
   SMALL: "small",

--- a/packages/moeum-components/src/components/BottomSheet/index.ts
+++ b/packages/moeum-components/src/components/BottomSheet/index.ts
@@ -1,0 +1,2 @@
+export { BottomSheet } from "./BottomSheet";
+export type { BottomSheetProps } from "./BottomSheet.type";

--- a/packages/moeum-components/src/index.ts
+++ b/packages/moeum-components/src/index.ts
@@ -14,6 +14,7 @@ export { Checkbox } from "./components/Checkbox";
 export { Toggle } from "./components/Toggle";
 export { Select } from "./components/Select";
 export { Popup } from "./components/Popup";
+export { BottomSheet } from "./components/BottomSheet";
 
 export { safeLocalStorage, safeSessionStorage } from "./shared/storage";
 export { RouterProvider, useRouter } from "./hooks/useRouter";

--- a/packages/moeum-components/src/style/index.scss
+++ b/packages/moeum-components/src/style/index.scss
@@ -16,3 +16,4 @@
 @use "../components/Select/Select.scss";
 @use "../components/Toggle/Toggle.scss";
 @use "../components/Popup/Popup.scss";
+@use "../components/BottomSheet/BottomSheet.scss";

--- a/packages/moeum-components/src/style/index.scss
+++ b/packages/moeum-components/src/style/index.scss
@@ -16,4 +16,3 @@
 @use "../components/Select/Select.scss";
 @use "../components/Toggle/Toggle.scss";
 @use "../components/Popup/Popup.scss";
-@use "../components/BottomSheet/BottomSheet.scss";


### PR DESCRIPTION
## 📝 PR 설명
BottomSheet 컴포넌트를 추가합니다.
<!-- PR 설명 -->

## 관련된 이슈 넘버
close #112 
<!-- close #1 -->

## ✅ 작업 목록
- BottomSheet 컴포넌트 추가
- 디자인토큰 적용
<!-- 이슈 작업한 내용 -->

## 📚 논의사항
<!-- 이 PR에서 더 논의할 사항 혹은 리뷰어에게 확인 요청하고 싶은 부분 기재 -->

@ChicoCrew 
- 실제 예시와 같이 padding을 미리 넣게되면 button과 같은 영역에서 터치영역이 줄어들게되어서 현재는 따로 여백을 두지 않고 있습니다.
  - https://github.com/team-moeum/moeum-design-system/issues/112#issuecomment-2743217709
- 버튼 영역은 [popup](https://github.com/team-moeum/moeum-design-system/issues/121)과 동일하게 1개인 케이스와 2개인 케이스를 고려하면 될지 궁금합니다.

## 📚 ETC

<!-- Screenshot, References 기재 -->
