### PR TITLE
feat(@moeum/components): 컴포넌트 Tabs

### DIFF
--- a/packages/moeum-components/src/components/Tabs/Tabs.scss
+++ b/packages/moeum-components/src/components/Tabs/Tabs.scss
@@ -1,0 +1,63 @@
+$tabs-height: 48px;
+$tabs-padding: var(--seed-spacing-200);
+$tabs-indicator-height: calc($tabs-height - ($tabs-padding * 2));
+$tabs-transition: all 0.2s ease-in-out;
+
+.tabs {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+}
+
+.tabs--list,
+.tabs--trigger,
+.tabs--indicator {
+  box-sizing: border-box;
+}
+
+.tabs--list-wrapper {
+  position: relative;
+}
+
+.tabs--list {
+  display: flex;
+  height: $tabs-height;
+  padding: $tabs-padding;
+  gap: var(--seed-spacing-200);
+  border-radius: var(--seed-rounding-500);
+  background-color: var(--seed-ui-color-background-chips);
+}
+
+.tabs--indicator {
+  position: absolute;
+  top: $tabs-padding;
+  left: 0;
+  height: $tabs-indicator-height;
+  box-shadow: 4px 4px 20px 0px rgba(0, 0, 0, 0.08);
+  background-color: var(--seed-ui-color-background-white);
+  border-radius: var(--seed-rounding-500);
+  transition: $tabs-transition;
+  z-index: 0;
+}
+
+.tabs--trigger {
+  position: relative;
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--seed-font-size-s);
+  border-radius: var(--seed-rounding-400);
+  transition: $tabs-transition;
+  z-index: 1;
+
+  &[data-state="inactive"] {
+    color: var(--seed-ui-color-text-lite);
+    font-weight: var(--seed-font-weight-400);
+  }
+
+  &[data-state="active"] {
+    color: var(--seed-ui-color-text-black);
+    font-weight: var(--seed-font-weight-700);
+  }
+}

--- a/packages/moeum-components/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/moeum-components/src/components/Tabs/Tabs.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import * as Tabs from "./Tabs";
 import { useState } from "react";
+import { Tabs } from "./Tabs";
 
 /**
  * **radix docs**
@@ -8,7 +8,7 @@ import { useState } from "react";
  */
 const meta = {
   title: "Components/Tabs",
-  component: Tabs.Root,
+  component: Tabs,
   parameters: {
     layout: "centered"
   },
@@ -34,27 +34,23 @@ const meta = {
       description: "초기 활성 tab 값을 설정"
     }
   }
-} satisfies Meta<typeof Tabs.Root>;
+} satisfies Meta<typeof Tabs>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
+    width: "360px",
+    tabItems: [
+      { value: "tab1", text: "Tab1", content: <div></div> },
+      { value: "tab2", text: "Tab2", content: <div></div> },
+      { value: "tab3", text: "Tab3", content: <div></div> }
+    ],
+    defaultValue: "tab1",
     dir: "ltr"
   },
-  render: args => (
-    <Tabs.Root {...args}>
-      <Tabs.List>
-        <Tabs.Trigger value="tab1">Tab1</Tabs.Trigger>
-        <Tabs.Trigger value="tab2">Tab2</Tabs.Trigger>
-        <Tabs.Trigger value="tab3">Tab3</Tabs.Trigger>
-      </Tabs.List>
-      <Tabs.Content value="tab1">Tab1 Content</Tabs.Content>
-      <Tabs.Content value="tab2">Tab2 Content</Tabs.Content>
-      <Tabs.Content value="tab3">Tab3 Content</Tabs.Content>
-    </Tabs.Root>
-  )
+  render: args => <Tabs {...args} key={`tabs_${args.dir}_${args.defaultValue}`} />
 };
 
 export function ControlledTabs() {
@@ -66,15 +62,17 @@ export function ControlledTabs() {
   };
 
   return (
-    <Tabs.Root value={value} onValueChange={handleChangeTab}>
-      <Tabs.List>
-        <Tabs.Trigger value="tab1">Tab1</Tabs.Trigger>
-        <Tabs.Trigger value="tab2">Tab2</Tabs.Trigger>
-        <Tabs.Trigger value="tab3">Tab3</Tabs.Trigger>
-      </Tabs.List>
-      <Tabs.Content value="tab1">Tab1 Content</Tabs.Content>
-      <Tabs.Content value="tab2">Tab2 Content</Tabs.Content>
-      <Tabs.Content value="tab3">Tab3 Content</Tabs.Content>
-    </Tabs.Root>
+    <div style={{ width: "calc(100vw * 0.5)", minWidth: 320, maxWidth: 540 }}>
+      <Tabs
+        tabItems={[
+          { value: "tab1", text: "Tab1", content: <div>Tab1 Content</div> },
+          { value: "tab2", text: "Tab2", content: <div>Tab2 Content</div> },
+          { value: "tab3", text: "Tab3", content: <div>Tab3 Content</div> }
+        ]}
+        defaultValue="tab1"
+        value={value}
+        onValueChange={handleChangeTab}
+      />
+    </div>
   );
 }

--- a/packages/moeum-components/src/components/Tabs/Tabs.tsx
+++ b/packages/moeum-components/src/components/Tabs/Tabs.tsx
@@ -1,21 +1,32 @@
-import * as TabsBase from "@radix-ui/react-tabs";
+import { useRef } from "react";
+import { TabsProps } from "./Tabs.type";
+import { List, Root, Trigger, Content } from "./TabsBase";
+import { useTabsIndicator } from "./useTabsIndicator";
 
-const Root = ({ ...props }: TabsBase.TabsProps) => {
-  return <TabsBase.Root data-fotcamp-component="Tabs" {...props} />;
-};
+const Tabs: React.FC<TabsProps> = props => {
+  const { width = "100%", tabItems, value, ...rest } = props;
+  const listRef = useRef<HTMLDivElement>(null);
+  const { indicatorStyle } = useTabsIndicator({ listRef, tabItems });
 
-const List = ({ ...props }: TabsBase.TabsListProps) => {
-  return <TabsBase.List data-fotcamp-component="TabsList" {...props} />;
-};
-
-const Trigger = ({ ...props }: TabsBase.TabsTriggerProps) => {
-  return <TabsBase.Trigger data-fotcamp-component="TabsTrigger" {...props} />;
-};
-
-const Content = ({ ...props }: TabsBase.TabsContentProps) => {
   return (
-    <TabsBase.Content data-fotcamp-component="TabsContent" className="tabs-content" {...props} />
+    <Root value={value} {...rest} style={{ width }}>
+      <div ref={listRef} className="tabs--list-wrapper">
+        <List data-orientation="horizontal">
+          {tabItems.map(item => (
+            <Trigger key={`tabTrigger_${item.value}`} value={item.value}>
+              {item.text}
+            </Trigger>
+          ))}
+        </List>
+        <div className="tabs--indicator" style={indicatorStyle} />
+      </div>
+      {tabItems.map(item => (
+        <Content key={`tabContent_${item.value}`} value={item.value}>
+          {item.content}
+        </Content>
+      ))}
+    </Root>
   );
 };
 
-export { Root, List, Trigger, Content };
+export { Tabs };

--- a/packages/moeum-components/src/components/Tabs/Tabs.tsx
+++ b/packages/moeum-components/src/components/Tabs/Tabs.tsx
@@ -6,7 +6,7 @@ import { useTabsIndicator } from "./useTabsIndicator";
 const Tabs: React.FC<TabsProps> = props => {
   const { width = "100%", tabItems, value, ...rest } = props;
   const listRef = useRef<HTMLDivElement>(null);
-  const { indicatorStyle } = useTabsIndicator({ listRef, tabItems });
+  const { indicatorStyle } = useTabsIndicator({ listRef });
 
   return (
     <Root value={value} {...rest} style={{ width }}>

--- a/packages/moeum-components/src/components/Tabs/Tabs.type.ts
+++ b/packages/moeum-components/src/components/Tabs/Tabs.type.ts
@@ -14,7 +14,6 @@ interface TabsProps extends Omit<TabsBase.TabsProps, "children"> {
 
 interface UseTabsIndicatorProps {
   listRef: RefObject<HTMLDivElement>;
-  tabItems: TabsProps["tabItems"];
 }
 
 export { TabsProps, TabItem, UseTabsIndicatorProps };

--- a/packages/moeum-components/src/components/Tabs/Tabs.type.ts
+++ b/packages/moeum-components/src/components/Tabs/Tabs.type.ts
@@ -1,0 +1,20 @@
+import * as TabsBase from "@radix-ui/react-tabs";
+import { ReactNode, RefObject } from "react";
+
+interface TabItem {
+  value: string;
+  text: string;
+  content: ReactNode;
+}
+
+interface TabsProps extends Omit<TabsBase.TabsProps, "children"> {
+  width?: string;
+  tabItems: TabItem[];
+}
+
+interface UseTabsIndicatorProps {
+  listRef: RefObject<HTMLDivElement>;
+  tabItems: TabsProps["tabItems"];
+}
+
+export { TabsProps, TabItem, UseTabsIndicatorProps };

--- a/packages/moeum-components/src/components/Tabs/TabsBase.tsx
+++ b/packages/moeum-components/src/components/Tabs/TabsBase.tsx
@@ -1,0 +1,24 @@
+import * as TabsBase from "@radix-ui/react-tabs";
+import "./Tabs.scss";
+
+const Root = ({ ...props }: TabsBase.TabsProps) => {
+  return <TabsBase.Root data-moeum-component="Tabs" className="tabs" {...props} />;
+};
+
+const List = ({ ...props }: TabsBase.TabsListProps) => {
+  return <TabsBase.List data-moeum-component="TabsList" className="tabs--list" {...props} />;
+};
+
+const Trigger = ({ ...props }: TabsBase.TabsTriggerProps) => {
+  return (
+    <TabsBase.Trigger data-moeum-component="TabsTrigger" className="tabs--trigger" {...props} />
+  );
+};
+
+const Content = ({ ...props }: TabsBase.TabsContentProps) => {
+  return (
+    <TabsBase.Content data-moeum-component="TabsContent" className="tabs--content" {...props} />
+  );
+};
+
+export { Root, List, Trigger, Content };

--- a/packages/moeum-components/src/components/Tabs/useTabsIndicator.ts
+++ b/packages/moeum-components/src/components/Tabs/useTabsIndicator.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, RefObject } from "react";
 import { UseTabsIndicatorProps } from "./Tabs.type";
 
 /**
@@ -6,14 +6,12 @@ import { UseTabsIndicatorProps } from "./Tabs.type";
  * @param {UseTabsIndicatorProps} props - 탭 인디케이터 설정
  * @returns {Object} indicatorStyle - 인디케이터의 스타일 객체
  */
-const useTabsIndicator = ({ listRef, tabItems }: UseTabsIndicatorProps) => {
+const useTabsIndicator = ({ listRef }: UseTabsIndicatorProps) => {
   const [indicatorStyle, setIndicatorStyle] = useState<React.CSSProperties>({});
 
   // 활성화된 탭의 위치를 기반으로 인디케이터의 위치를 계산합니다.
-  const updateIndicatorPosition = useCallback(() => {
-    if (!listRef.current) return;
-
-    const activeTab = listRef.current.querySelector('[data-state="active"]');
+  const updateIndicatorPosition = useCallback((listRef: RefObject<HTMLDivElement>) => {
+    const activeTab = listRef.current?.querySelector('[data-state="active"]');
     if (!activeTab) return;
 
     const { offsetLeft, offsetWidth } = activeTab as HTMLElement;
@@ -21,13 +19,13 @@ const useTabsIndicator = ({ listRef, tabItems }: UseTabsIndicatorProps) => {
       transform: `translateX(${offsetLeft}px)`,
       width: `${offsetWidth}px`
     });
-  }, [listRef]);
+  }, []);
 
   useEffect(() => {
     if (!listRef.current) return;
 
     // 초기 인디케이터 위치 설정
-    updateIndicatorPosition();
+    updateIndicatorPosition(listRef);
 
     /**
      * 탭의 상태 변화를 감지하는 MutationObserver
@@ -36,7 +34,7 @@ const useTabsIndicator = ({ listRef, tabItems }: UseTabsIndicatorProps) => {
     const mutationObserver = new MutationObserver(mutations => {
       mutations.forEach(mutation => {
         if (mutation.type === "attributes" && mutation.attributeName === "data-state") {
-          updateIndicatorPosition();
+          updateIndicatorPosition(listRef);
         }
       });
     });
@@ -46,7 +44,7 @@ const useTabsIndicator = ({ listRef, tabItems }: UseTabsIndicatorProps) => {
      * 윈도우 리사이즈나 탭 크기 변경 시 인디케이터 위치를 업데이트합니다.
      */
     const resizeObserver = new ResizeObserver(() => {
-      updateIndicatorPosition();
+      updateIndicatorPosition(listRef);
     });
 
     // 모든 탭 트리거에 옵저버 적용
@@ -60,7 +58,7 @@ const useTabsIndicator = ({ listRef, tabItems }: UseTabsIndicatorProps) => {
       mutationObserver.disconnect();
       resizeObserver.disconnect();
     };
-  }, [listRef, updateIndicatorPosition, tabItems.length]);
+  }, [listRef, updateIndicatorPosition]);
 
   return {
     indicatorStyle

--- a/packages/moeum-components/src/components/Tabs/useTabsIndicator.ts
+++ b/packages/moeum-components/src/components/Tabs/useTabsIndicator.ts
@@ -1,0 +1,70 @@
+import { useEffect, useState, useCallback } from "react";
+import { UseTabsIndicatorProps } from "./Tabs.type";
+
+/**
+ * 탭 인디케이터의 위치를 계산하고 관리하는 커스텀 훅
+ * @param {UseTabsIndicatorProps} props - 탭 인디케이터 설정
+ * @returns {Object} indicatorStyle - 인디케이터의 스타일 객체
+ */
+const useTabsIndicator = ({ listRef, tabItems }: UseTabsIndicatorProps) => {
+  const [indicatorStyle, setIndicatorStyle] = useState<React.CSSProperties>({});
+
+  // 활성화된 탭의 위치를 기반으로 인디케이터의 위치를 계산합니다.
+  const updateIndicatorPosition = useCallback(() => {
+    if (!listRef.current) return;
+
+    const activeTab = listRef.current.querySelector('[data-state="active"]');
+    if (!activeTab) return;
+
+    const { offsetLeft, offsetWidth } = activeTab as HTMLElement;
+    setIndicatorStyle({
+      transform: `translateX(${offsetLeft}px)`,
+      width: `${offsetWidth}px`
+    });
+  }, [listRef]);
+
+  useEffect(() => {
+    if (!listRef.current) return;
+
+    // 초기 인디케이터 위치 설정
+    updateIndicatorPosition();
+
+    /**
+     * 탭의 상태 변화를 감지하는 MutationObserver
+     * data-state 속성이 변경될 때마다 인디케이터 위치를 업데이트합니다.
+     */
+    const mutationObserver = new MutationObserver(mutations => {
+      mutations.forEach(mutation => {
+        if (mutation.type === "attributes" && mutation.attributeName === "data-state") {
+          updateIndicatorPosition();
+        }
+      });
+    });
+
+    /**
+     * 탭의 크기 변화를 감지하는 ResizeObserver
+     * 윈도우 리사이즈나 탭 크기 변경 시 인디케이터 위치를 업데이트합니다.
+     */
+    const resizeObserver = new ResizeObserver(() => {
+      updateIndicatorPosition();
+    });
+
+    // 모든 탭 트리거에 옵저버 적용
+    const triggers = listRef.current.querySelectorAll<HTMLElement>('[role="tab"]');
+    triggers.forEach(trigger => {
+      mutationObserver.observe(trigger, { attributes: true });
+      resizeObserver.observe(trigger);
+    });
+
+    return () => {
+      mutationObserver.disconnect();
+      resizeObserver.disconnect();
+    };
+  }, [listRef, updateIndicatorPosition, tabItems.length]);
+
+  return {
+    indicatorStyle
+  };
+};
+
+export { useTabsIndicator };


### PR DESCRIPTION
## 📝 PR 설명
Tabs Component 추가 합니다.
<!-- PR 설명 -->

## 관련된 이슈 넘버
close #108 
<!-- close #1 -->

## ✅ 작업 목록
- Tabs Component 추가
- 디자인 토큰 사용
<!-- 이슈 작업한 내용 -->

## 📚 논의사항
- https://github.com/team-moeum/moeum-design-system/issues/108#issuecomment-2780379411 의 논의가 아직 끝나지 않았지만 1차적인 디자인 토큰 적용 및 구현을 목표로 작업 했습니다. 논의 완료 후 변경 작업 하겠습니다! (@ChicoCrew, @seungdeok)

## 📚 ETC
- Tabs 의 Base가 되는 radix ui 기반 Component는 `TabsBase.tsx`에 남겨두어 사용하였습니다.
- 구성중인 디자인 시스템에 어떻게 Tabs를 사용하면 좋을지에 관해 고민을 하였고, 기존에 `<Tabs.Content />`, `<Tabs.Trigger />`의 사용을 지양하고 하나의 `<Tabs />`로 사용 할 수 있게 변경했습니다. 이에따라 props에 Tab의 종속되는 Content를 넣을 수 있게 하였고 아래의 library를 참고했습니다.
https://www.npmjs.com/package/rc-tabs

<!-- Screenshot, References 기재 -->
